### PR TITLE
Update WebSocket version from hixie-76 to RFC6455

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 gem "eventmachine"
-gem "libwebsocket"
+gem "websocket"
 
 group :development do
   gem "rspec", "~> 2.3.0"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This gem implements a simple websocket client inside EventMachine.
 This might be useful for testing web socket servers or consuming
 WebSocket APIs. In particular it supports the
-[hixie-76](http://tools.ietf.org/html/draft-hixie-thewebsocketprotocol-76)
+[RFC6455](http://tools.ietf.org/html/rfc6455)
 version of the protocol, which is also implemented in Chrome and
 Safari. At this time, the wss (WebSocket over SSL) protocol is not
 supported.
@@ -24,10 +24,10 @@ EM.run do
   conn.errback do |e|
     puts "Got error: #{e}"
   end
-  
+
   conn.stream do |msg|
     puts "<#{msg}>"
-    if msg == "done"
+    if msg.data == "done"
       conn.close_connection
     end
   end

--- a/em-websocket-client.gemspec
+++ b/em-websocket-client.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{em-websocket-client}
-  s.version = "0.1.1"
+  s.version = "0.1.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Micah Wylde"]
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<eventmachine>, [">= 0"])
-      s.add_runtime_dependency(%q<libwebsocket>, [">= 0"])
+      s.add_runtime_dependency(%q<websocket>, [">= 0"])
       s.add_development_dependency(%q<rspec>, ["~> 2.3.0"])
       s.add_development_dependency(%q<yard>, ["~> 0.6.0"])
       s.add_development_dependency(%q<bundler>, ["~> 1.0.0"])
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<rcov>, [">= 0"])
     else
       s.add_dependency(%q<eventmachine>, [">= 0"])
-      s.add_dependency(%q<libwebsocket>, [">= 0"])
+      s.add_dependency(%q<websocket>, [">= 0"])
       s.add_dependency(%q<rspec>, ["~> 2.3.0"])
       s.add_dependency(%q<yard>, ["~> 0.6.0"])
       s.add_dependency(%q<bundler>, ["~> 1.0.0"])
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<eventmachine>, [">= 0"])
-    s.add_dependency(%q<libwebsocket>, [">= 0"])
+    s.add_dependency(%q<websocket>, [">= 0"])
     s.add_dependency(%q<rspec>, ["~> 2.3.0"])
     s.add_dependency(%q<yard>, ["~> 0.6.0"])
     s.add_dependency(%q<bundler>, ["~> 1.0.0"])

--- a/lib/em-websocket-client.rb
+++ b/lib/em-websocket-client.rb
@@ -1,33 +1,5 @@
 require 'uri'
-require 'libwebsocket'
-
-# Monkey patch libwebsocket to support parameters in URLs
-module LibWebSocket
-  class URL
-    def parse(string)
-      return nil unless string.is_a?(String)
-
-      uri = Addressable::URI.parse(string)
-
-      scheme = uri.scheme
-      return nil unless scheme
-
-      self.secure = true if scheme.match(/ss\Z/m)
-
-      host = uri.host
-      host = '/' unless host && host != ''
-      self.host = host
-      self.port = uri.port.to_s if uri.port
-
-      request_uri = uri.path
-      request_uri = '/' unless request_uri && request_uri != ''
-      request_uri += "?" + uri.query if uri.query
-      self.resource_name = request_uri
-
-      return self
-    end
-  end
-end
+require 'websocket'
 
 module EventMachine
   class WebSocketClient < Connection
@@ -44,36 +16,35 @@ module EventMachine
 
     def post_init
       @handshaked = false
-      @frame  = LibWebSocket::Frame.new
+      @frame  = ::WebSocket::Frame::Incoming::Client.new
     end
 
     def connection_completed
-      @hs = LibWebSocket::OpeningHandshake::Client.new(:url => @url)
+      @hs = ::WebSocket::Handshake::Client.new(:url => @url)
       send_data @hs.to_s
     end
 
     def stream &cb; @stream = cb; end
     def disconnect &cb; @disconnect = cb; end
-    
+
     def receive_data data
       if !@handshaked
-        result = @hs.parse data
-        fail @hs.error unless result
-        
-        if @hs.done?
+        @hs << data
+        if @hs.finished?
           @handshaked = true
           succeed
         end
       else
-        @frame.append(data)
+        @frame << data
         while msg = @frame.next
           @stream.call(msg) if @stream
         end
       end
     end
 
-    def send_msg s
-      frame = LibWebSocket::Frame.new(s)
+    def send_msg(s, args)
+      type = args[:type] || :text
+      frame = ::WebSocket::Frame::Outgoing::Client.new(:data => s, :type => type, :version => @hs.version)
       send_data frame.to_s
     end
 

--- a/lib/em-websocket-client.rb
+++ b/lib/em-websocket-client.rb
@@ -42,7 +42,7 @@ module EventMachine
       end
     end
 
-    def send_msg(s, args)
+    def send_msg(s, args={})
       type = args[:type] || :text
       frame = ::WebSocket::Frame::Outgoing::Client.new(:data => s, :type => type, :version => @hs.version)
       send_data frame.to_s


### PR DESCRIPTION
Hi, mwylde.
I'm a developer with WebSocket in Japan.

'em-websocket-client' is a good tool for Goliath testing,
but WebSocket version is until hixie-76, so can not testing RFC6455 version.

I try to update using RFC6455 version.
Please confirm and update gem if you feel good.

Thanks 
