### PR TITLE
Add connection callback

### DIFF
--- a/lib/em-websocket-client.rb
+++ b/lib/em-websocket-client.rb
@@ -21,9 +21,9 @@ module EventMachine
     end
 
     def connection_completed
+      @connect.yield
       @hs = ::WebSocket::Handshake::Client.new(:url => @url)
       send_data @hs.to_s
-      @connect.yield
     end
 
     def stream &cb; @stream = cb; end

--- a/lib/em-websocket-client.rb
+++ b/lib/em-websocket-client.rb
@@ -21,7 +21,7 @@ module EventMachine
     end
 
     def connection_completed
-      @connect.yield
+      @connect.yield if @connect
       @hs = ::WebSocket::Handshake::Client.new(:url => @url)
       send_data @hs.to_s
     end

--- a/lib/em-websocket-client.rb
+++ b/lib/em-websocket-client.rb
@@ -23,9 +23,11 @@ module EventMachine
     def connection_completed
       @hs = ::WebSocket::Handshake::Client.new(:url => @url)
       send_data @hs.to_s
+      @connect.yield
     end
 
     def stream &cb; @stream = cb; end
+    def connected &cb; @connect = cb; end
     def disconnect &cb; @disconnect = cb; end
 
     def receive_data data


### PR DESCRIPTION
The connection callback allows us to initialise TLS, if required, before handshaking the WebSocket. This allows us to connect to WebSocket servers fronted by stunnel/tls.
