### PR TITLE
Expose websocket protocol_version and origin attributes

### DIFF
--- a/lib/em-websocket-client.rb
+++ b/lib/em-websocket-client.rb
@@ -7,11 +7,15 @@ module EventMachine
     include Deferrable
 
     attr_accessor :url
+    attr_accessor :protocol_version
+    attr_accessor :origin
 
-    def self.connect uri
+    def self.connect(uri, opts={})
       p_uri = URI.parse(uri)
       conn = EM.connect(p_uri.host, p_uri.port || 80, self) do |c|
         c.url = uri
+        c.protocol_version = opts[:version]
+        c.origin = opts[:origin]
       end
     end
 
@@ -22,7 +26,9 @@ module EventMachine
 
     def connection_completed
       @connect.yield if @connect
-      @hs = ::WebSocket::Handshake::Client.new(:url => @url)
+      @hs = ::WebSocket::Handshake::Client.new(:url     => @url,
+                                               :origin  => @origin,
+                                               :version => @protocol_version)
       send_data @hs.to_s
     end
 

--- a/lib/em-websocket-client.rb
+++ b/lib/em-websocket-client.rb
@@ -43,6 +43,8 @@ module EventMachine
           @handshaked = true
           succeed
         end
+
+        receive_data(@hs.leftovers) if @hs.leftovers
       else
         @frame << data
         while msg = @frame.next


### PR DESCRIPTION
Greetings I ran into a few issues when using em-websocket-client in the em-websocket test suite. I'm attempting to update em-websocket to the latest http_parser.rb version which also entails updating em-http-request for the spec suite and that no longer supports websockets.

To be able to incorporate em-websocket-client we need to be able to write to the protocol_version and origin attributes of the internal handshake instance so as to properly test those in em-websocket. The first patch of the two adds this feature.

The second fixes an edge case I ran into w/ the em-websocket test suite where the websocket handshake content and initial data were sent together, and em-websocket-client wasn't picking up the remaining bits waiting in the handshake instance. The patch simply picks this up if set and processes it as normal.

Shout out if anything looks off or if anything needs to be changed to get this in. Thanks.
